### PR TITLE
Be less defensive in check for ALTER TABLE

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -1,11 +1,11 @@
 [extension]
-name = "pg_ivm"
-version = "1.8.0+partitioning"
-repository = "https://github.com/sraoss/pg_ivm"
+name = "tembo_ivm"
+version = "1.9.1"
+repository = "https://github.com/tembo-io/pg_ivm"
 license = "PostgreSQL"
 description = "IVM (Incremental View Maintenance) implementation as a PostgreSQL extension"
 homepage = "https://www.sraoss.co.jp/index_en/"
-documentation = "https://github.com/sraoss/pg_ivm"
+documentation = "https://github.com/tembo-io/pg_ivm"
 categories = ["change_data_capture"]
 
 [dependencies]

--- a/matview.c
+++ b/matview.c
@@ -713,7 +713,7 @@ changes_partitions(PG_FUNCTION_ARGS)
   /* this function is intended for ALTER TABLE only */
 	if (cmd->type != SCT_AlterTable)
   {
-		elog(ERROR, "command is not ALTER TABLE");
+		return BoolGetDatum(false);
   }
 
   /* expect at least one sub-command */


### PR DESCRIPTION
RENAME seems to have a different command type, even though this call is clearly guarded by an event trigger that only matches ALTER TABLE.

Updated the `trunk.toml` even though we build this from within the trunk repo now.